### PR TITLE
Update sync.py to not fail after successfully importing a translation

### DIFF
--- a/src/wagtail_localize_smartling/sync.py
+++ b/src/wagtail_localize_smartling/sync.py
@@ -228,7 +228,7 @@ def _download_and_apply_translations(job: "Job") -> None:
                 po_file = polib.pofile(f.read().decode("utf-8"))
                 translation.import_po(po_file)
                 translation_imported.send(
-                    sender=Job,
+                    sender=job.__class__,
                     instance=job,
                     translation=translation,
                 )


### PR DESCRIPTION
This changset attemps to fix #8, where the use of an unimported `Job` class (more of a type) was triggering a `NameError` when passing it into a Django Signal.

This may not be the preferred way to deal with it - please feel free to ignore if there's a better fix