### PR TITLE
Quick tweaks and improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,13 @@
 
 ## Features
 
-- [ ] Django system checks
-- [ ] Signals
-- [ ] PyPI publishing from CI
+- [x] Django system checks
+- [x] Signals
+- [x] PyPI publishing from CI
 - [x] Indicate Smartling translation status on translation pages:
     - [x] Synced translation edit page (target)
-- [ ] Job listing and job details in Wagtail admin
+- [x] Job listing in Wagtail admin (Reports > Smartling jobs)
+  - [ ] and job details in Wagtail admin
 - [x] Runtime checks/warnings for compatibility of
       `Locale`s/`WAGTAIL_CONTENT_LANGUAGES`/`LANGUAGE_CODE` with the configured
       Smartling project. Dashboard/overview page to surface errors.

--- a/src/wagtail_localize_smartling/api/types.py
+++ b/src/wagtail_localize_smartling/api/types.py
@@ -54,7 +54,7 @@ class ListJobsResponseData(TypedDict):
 class JobStatus(models.TextChoices):
     UNSYNCED = ("UNSYNCED", _("Unsynced"))
     DRAFT = ("DRAFT", _("Draft"))
-    AWAITING_AUTHORISATION = ("AWAITING_AUTHORIZATION", _("Awaiting authorization"))
+    AWAITING_AUTHORIZATION = ("AWAITING_AUTHORIZATION", _("Awaiting authorization"))
     IN_PROGRESS = ("IN_PROGRESS", _("In progress"))
     COMPLETED = ("COMPLETED", _("Completed"))
     CANCELLED = ("CANCELLED", _("Cancelled"))

--- a/src/wagtail_localize_smartling/models.py
+++ b/src/wagtail_localize_smartling/models.py
@@ -138,9 +138,9 @@ class ProjectTargetLocale(models.Model):
 
 @register_translation_component(
     required=smartling_settings.REQUIRED,
-    heading=_("Send translation to Smartling"),
-    enable_text=_("Send to Smartling"),
-    disable_text=_("Do not send to Smartling"),
+    heading=_("Mark translation for Smartling processing"),
+    enable_text=_("Click to mark for Smartling processing"),
+    disable_text=_("Click to skip Smartling processing"),
 )
 class Job(SyncedModel):
     """

--- a/src/wagtail_localize_smartling/sync.py
+++ b/src/wagtail_localize_smartling/sync.py
@@ -36,7 +36,7 @@ class FileURIMismatch(SyncJobException):
 
 PENDING_STATUSES = (
     JobStatus.DRAFT,
-    JobStatus.AWAITING_AUTHORISATION,
+    JobStatus.AWAITING_AUTHORIZATION,
     JobStatus.IN_PROGRESS,
 )
 TRANSLATED_STATUSES = (JobStatus.COMPLETED, JobStatus.CLOSED)

--- a/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
+++ b/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
@@ -4,8 +4,8 @@ from django import template
 from django.utils.translation import gettext as _
 from wagtail.admin import messages as admin_messages
 from wagtail_localize_smartling.models import Job
-
-from ..utils import format_smartling_job_url
+from wagtail_localize_smartling.sync import UNTRANSLATED_STATUSES
+from wagtail_localize_smartling.utils import format_smartling_job_url
 
 
 register = template.Library()
@@ -22,7 +22,7 @@ def smartling_edit_translation_message(context):
     }
 
     translation = context["translation"]
-    jobs = translation.smartling_jobs.all()
+    jobs = translation.smartling_jobs.exclude(status__in=UNTRANSLATED_STATUSES)
 
     jobs_exists = bool(jobs)
     inclusion_context["show_message"] = jobs_exists

--- a/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
+++ b/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
@@ -30,13 +30,16 @@ def smartling_edit_translation_message(context):
     if not jobs_exists:
         return inclusion_context
 
+    # Jobs are ordered by `first_synced_at`, with null values coming at the top
+    # then pk descending. So we choose the first in the list. This may mean the job
+    # status will show as unsynced in the message below
+    latest_job = list(jobs)[0]
     message = _(
         "This translation is managed by Smartling. Changes made here will be lost the "
-        "next time translations are imported from Smartling."
+        "next time translations are imported from Smartling. "
+        f"Job status: {latest_job.get_status_display()}"
     )
     buttons = []
-
-    latest_job = list(jobs)[-1]
     if smartling_url := format_smartling_job_url(latest_job):
         buttons.append(
             admin_messages.button(

--- a/tests/translation_components/test_submit_translations.py
+++ b/tests/translation_components/test_submit_translations.py
@@ -7,6 +7,7 @@ import pytest
 
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from django.utils import timezone
 from pytest_django.asserts import assertRedirects
 from wagtail.models import Locale, Page
 from wagtail_localize.models import (
@@ -14,9 +15,13 @@ from wagtail_localize.models import (
     TranslationSource,
     get_edit_url,
 )
+from wagtail_localize_smartling.api.types import JobStatus
 from wagtail_localize_smartling.models import Job
 
 from testapp.factories import InfoPageFactory
+
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
@@ -26,7 +31,6 @@ from testapp.factories import InfoPageFactory
         [("de", "fr")],
     ],
 )
-@pytest.mark.django_db()
 def test_submitting_for_translation_with_no_existing_jobs_no_child_pages(
     client, root_page, superuser, target_locales, smartling_project
 ):
@@ -97,6 +101,88 @@ def test_submitting_for_translation_with_no_existing_jobs_no_child_pages(
     assert job.first_synced_at is None
     assert job.last_synced_at is None
     assert job.due_date is None
+
+
+@pytest.mark.parametrize(
+    "status,show_message",
+    [
+        (JobStatus.UNSYNCED, True),
+        (JobStatus.AWAITING_AUTHORIZATION, True),
+        (JobStatus.IN_PROGRESS, True),
+        (JobStatus.COMPLETED, True),
+        (JobStatus.CANCELLED, False),
+        (JobStatus.DELETED, False),
+    ],
+)
+def test_managed_by_message_on_translation(
+    client, root_page, superuser, smartling_project, status, show_message
+):
+    client.force_login(superuser)
+
+    page = InfoPageFactory(parent=root_page, title="Component test page")
+
+    target_locale_ids = Locale.objects.values_list("pk", flat=True).filter(
+        language_code__in=["de"]
+    )
+
+    component_form_prefix = f"component-{Job._meta.db_table}"
+
+    submit_url = reverse(
+        "wagtail_localize:submit_page_translation",
+        kwargs={"page_id": page.pk},
+    )
+
+    post_response = client.post(
+        submit_url,
+        data={
+            "locales": target_locale_ids,
+            f"{component_form_prefix}-enabled": True,
+            f"{component_form_prefix}-due_date": "",
+        },
+    )
+
+    translation_source = TranslationSource.objects.get_for_instance(page)  # pyright: ignore[reportAttributeAccessIssue]
+    translations = Translation.objects.filter(
+        source=translation_source,
+        target_locale_id__in=target_locale_ids,
+    )
+    assert [t.target_locale.language_code for t in translations] == ["de"]
+
+    redirect_url = translations[0].get_target_instance_edit_url()
+
+    assert redirect_url is not None
+    assertRedirects(post_response, redirect_url)
+
+    job = Job.objects.get(
+        first_synced_at=None,
+        last_synced_at=None,
+        translation_source__object__content_type=ContentType.objects.get_for_model(
+            Page
+        ),
+        translation_source__object__translation_key=page.translation_key,
+    )
+
+    job.status = status
+    update_fields = ["status"]
+    if job.status != JobStatus.UNSYNCED:
+        now = timezone.now()
+        job.first_synced_at = now
+        job.last_synced_at = now
+        job.translation_job_uid = "foo"
+        update_fields += ["first_synced_at", "last_synced_at", "translation_job_uid"]
+
+    job.save(update_fields=update_fields)
+
+    response = client.get(redirect_url)
+    expected = (
+        "This translation is managed by Smartling. Changes made here will be "
+        "lost the next time translations are imported from Smartling. "
+        f"Job status: {job.get_status_display()}"  # pyright: ignore[reportAttributeAccessIssue]
+    )
+    if show_message:
+        assert expected in response.content.decode("utf-8")
+    else:
+        assert expected not in response.content.decode("utf-8")
 
 
 # TODO test existing jobs in various states


### PR DESCRIPTION
This PR:

- changes the translation component wording (from "Send to Smartling" to "Click to mark for Smartling processing")
- adds the job status in the "This translation is managed by Smartling" message
- uses the latest job for the status and the "View in Smartling" button. Fixes #12
- hides the "managed" message for deleted or cancelled jobs