### PR TITLE
Add option to disable case-changing of language codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,17 @@ WAGTAIL_LOCALIZE_SMARTLING = {
 }
 ```
 
+    Note that by default, when syncing translations, the project will attempt to reformat a mixed-case, Smartling-style language code (e.g. `zh-CN`) into a core Django all-lowercase style (`zh-cn`). Depending on how lang codes are set up in your project, this behaviour may not be appropriate. You can disable it via the `REFORMAT_LANGUAGE_CODES` setting, which defaults to `True`:
+
+    ```python
+    WAGTAIL_LOCALIZE_SMARTLING = {
+        # ...
+        "REFORMAT_LANGUAGE_CODES": False
+    }
+
 The callback receives a `WAGTAIL_CONTENT_LANGUAGES` local code string and is expected to return
 a valid mapped locale id (or the original locale id).
+    ```
 
 4. Run migrations:
 

--- a/README.md
+++ b/README.md
@@ -58,31 +58,31 @@ integrates with the Smartling translation platform.
     }
     ```
 
-If your project locales do not match those in Smartling (e.g. `ro` in your project, `ro-RO` in Smartling),
-then you can provide a Wagtail locale id to Smartling locale id mapping via the `LOCALE_TO_SMARTLING_LOCALE` setting:
+    If your project locales do not match those in Smartling (e.g. `ro` in your project, `ro-RO` in Smartling),
+    then you can provide a Wagtail locale id to Smartling locale id mapping via the `LOCALE_TO_SMARTLING_LOCALE` setting:
 
-```python
-WAGTAIL_LOCALIZE_SMARTLING = {
-    "LOCALE_TO_SMARTLING_LOCALE": {
-        "ro": "ro-RO"
+    ```python
+    WAGTAIL_LOCALIZE_SMARTLING = {
+        "LOCALE_TO_SMARTLING_LOCALE": {
+            "ro": "ro-RO"
+        }
     }
-}
-```
+    ```
 
-... or you can specify a callable or a dotted path to a callable in the `LOCALE_MAPPING_CALLBACK` setting:
+    ... or you can specify a callable or a dotted path to a callable in the `LOCALE_MAPPING_CALLBACK` setting:
 
-```python
-def map_project_locale_to_smartling(locale: str) -> str:
-    if locale == "ro":
-        return "ro-RO"
-    return locale
+    ```python
+    def map_project_locale_to_smartling(locale: str) -> str:
+        if locale == "ro":
+            return "ro-RO"
+        return locale
 
 
-WAGTAIL_LOCALIZE_SMARTLING = {
-    # ...
-    "LOCALE_MAPPING_CALLBACK": "settings.map_project_locale_to_smartling"
-}
-```
+    WAGTAIL_LOCALIZE_SMARTLING = {
+        # ...
+        "LOCALE_MAPPING_CALLBACK": "settings.map_project_locale_to_smartling"
+    }
+    ```
 
     Note that by default, when syncing translations, the project will attempt to reformat a mixed-case, Smartling-style language code (e.g. `zh-CN`) into a core Django all-lowercase style (`zh-cn`). Depending on how lang codes are set up in your project, this behaviour may not be appropriate. You can disable it via the `REFORMAT_LANGUAGE_CODES` setting, which defaults to `True`:
 

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -26,6 +26,7 @@ class SmartlingSettings:
     SMARTLING_LOCALE_TO_LOCALE: "dict[str, str]" = dataclasses.field(
         default_factory=dict
     )
+    REFORMAT_LANGUAGE_CODES: bool = True
 
 
 def _init_settings() -> SmartlingSettings:
@@ -125,6 +126,11 @@ def _init_settings() -> SmartlingSettings:
         settings_kwargs["SMARTLING_LOCALE_TO_LOCALE"] = {
             v: k for k, v in LOCALE_TO_SMARTLING_LOCALE.items()
         }
+
+    if "REFORMAT_LANGUAGE_CODES" in settings_dict:
+        settings_kwargs["REFORMAT_LANGUAGE_CODES"] = bool(
+            settings_dict["REFORMAT_LANGUAGE_CODES"]
+        )
 
     return SmartlingSettings(**settings_kwargs)
 

--- a/src/wagtail_localize_smartling/utils.py
+++ b/src/wagtail_localize_smartling/utils.py
@@ -22,11 +22,16 @@ def format_smartling_locale_id(locale_id: str) -> str:
     (e.g. "en-us") whereas Smartling uses lower case for the language code and
     upper case for the region, if any (e.g. "en-US").
 
+    This behaviour is not applied if the REFORMAT_LANGUAGE_CODES setting is False
+
     Also, this applies any mapping defined by the LOCALE_MAPPING_CALLBACK or
     LOCALE_TO_SMARTLING_LOCALE settings.
     """
     # Apply any mapping defined in settings
     locale_id = smartling_settings.LOCALE_TO_SMARTLING_LOCALE.get(locale_id, locale_id)
+
+    if smartling_settings.REFORMAT_LANGUAGE_CODES is False:
+        return locale_id
 
     # Reformat to match Smartling's format/casing
     original_parts = locale_id.split("-")
@@ -41,9 +46,14 @@ def format_smartling_locale_id(locale_id: str) -> str:
 def format_wagtail_locale_id(locale_id: str) -> str:
     """
     The opposite of format_smartling_locale_id, return everything lower case.
+
+    This behaviour is not applied if the REFORMAT_LANGUAGE_CODES setting is False
     """
     # Apply any mapping defined in settings
     locale_id = smartling_settings.SMARTLING_LOCALE_TO_LOCALE.get(locale_id, locale_id)
+
+    if smartling_settings.REFORMAT_LANGUAGE_CODES is False:
+        return locale_id
 
     return locale_id.lower()
 


### PR DESCRIPTION
This changeset adds a new setting - `REFORMAT_LANGUAGE_CODES`, default `True`, which we can use to control whether w-l-s will reformat lang codes as part of the Smartling sync. 

By default w-l-s assumes the Django project will be using Django's core default of all-lowercase language codes (compared to Smartling's mixed-case approach) and forces all lang codes to the relevant style depending on the direction of travel. This change allows us to skip that step when importing strings back into Wagtail, (and the equivalent step when sending lang codes _to_ Smartling, too, just for consistency and no surprise).

### Testing
Manually tested locally. I have a stash locally with some tests for test_utils.py but neither `@override_settings` nor `mock.patch.object` seem to work for setting fake settings during a test - the former gets ignored and the latter blows up because the patched attribute can't be deleted/changed. If anyone has a tip about that, I'd welcome it

Resolves #17 