### PR TITLE
Small CI fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
           path: .coverage
           if-no-files-found: ignore
           retention-days: 1
+          include-hidden-files: true
 
   test-postgres:
     runs-on: ubuntu-latest
@@ -108,6 +109,7 @@ jobs:
           path: .coverage
           if-no-files-found: ignore
           retention-days: 1
+          include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.6.4  # keep in sync with pyproject.toml
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "pytest==8.3.2",
     "python-dotenv==1.0.1",
     "responses==0.25.0",
-    "ruff==0.5.7",
+    "ruff==0.6.4",  # keep in sync with pre-commit.yaml
     "tox",
     "tox-gh-actions",
     "wagtail-factories==4.2.1"
@@ -114,6 +114,7 @@ fixable = [
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 lines-between-types = 1
+known-local-folder = ["src", "tests", "testapp"]
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ typeCheckingMode = "standard"
 reportUnnecessaryTypeIgnoreComment = true
 # Make sure we're checking against the minimum supported Python version by
 # default. CI will check against all supported versions for us.
-pythonVersion = "3.8"
+pythonVersion = "3.11"
 
 
 [tool.ruff]

--- a/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
+++ b/src/wagtail_localize_smartling/templatetags/wagtail_localize_smartling_admin_tags.py
@@ -3,6 +3,7 @@ from typing import Any
 from django import template
 from django.utils.translation import gettext as _
 from wagtail.admin import messages as admin_messages
+
 from wagtail_localize_smartling.models import Job
 from wagtail_localize_smartling.sync import UNTRANSLATED_STATUSES
 from wagtail_localize_smartling.utils import format_smartling_job_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from wagtail.coreutils import get_supported_content_language_variant
 from wagtail.models import Locale, Page
 from wagtail_localize.models import LocaleSynchronization
+
 from wagtail_localize_smartling.api.client import client
 from wagtail_localize_smartling.api.types import (
     AuthenticateResponseData,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,6 +5,7 @@ import factory.django
 
 from wagtail.models import Locale
 from wagtail_localize.models import Translation
+
 from wagtail_localize_smartling import models as wls_models
 
 from testapp.factories import TranslationSourceFactory, UserFactory

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,7 @@ import pytest
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
+
 from wagtail_localize_smartling.settings import _init_settings
 
 

--- a/tests/translation_components/test_submit_translations.py
+++ b/tests/translation_components/test_submit_translations.py
@@ -15,6 +15,7 @@ from wagtail_localize.models import (
     TranslationSource,
     get_edit_url,
 )
+
 from wagtail_localize_smartling.api.types import JobStatus
 from wagtail_localize_smartling.models import Job
 


### PR DESCRIPTION
- fixes CI because of incompatible changes in actions/upload-artifact - https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/
- bumps the min pyright version to 3.11
- updates ruff while at it (and makes it consider src, tests and testapp as "local" folder)