### PR TITLE
Add support for Smartling CAT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ integrates with the Smartling translation platform.
         # This assumes the page is live and visible. If the page is a draft, you
         # will need a some custom work to expose the draft version of the page
         page = job.translation_source.get_source_instance()
-        page_url = page.url
+        page_url = page.full_url
 
         html = # code to render that page instance
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ integrates with the Smartling translation platform.
         return page_url, html
     ```
 
+    Note that if the syncing of the visual context fails, this will break the
+    overall sync to Smartling, leaving an inconsistent state:
+    there'll be a Job created in Smartling that's awaiting approval, but Wagtail
+    will still think the job needs to be created. This, in turn, will mean we get
+    duplicate job errors on the retry. Therefore, it is essential you have log
+    handling set up to catch the `ERROR`-level alert that will happen at this point.
+
 4. Run migrations:
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ integrates with the Smartling translation platform.
     }
     ```
 
+    ----
+
     If your project's locales do not match those in Smartling (e.g. `ro` in your
     project, `ro-RO` in Smartling), then you can provide a Wagtail locale ID to
     Smartling locale ID mapping via the `LOCALE_TO_SMARTLING_LOCALE` setting:
@@ -104,6 +106,8 @@ integrates with the Smartling translation platform.
 
     ```
 
+    ----
+
     If you need to customize the default Job description, you can specify a callable or a dotted path to a callable in
     the `JOB_DESCRIPTION_CALLBACK` setting:
 
@@ -122,6 +126,37 @@ integrates with the Smartling translation platform.
 
     The callback receives the default description string, the job `TranslationSource` instance, and the list of
     target `Translation`s. It expected to return string.
+
+    ----
+
+    If you want to pass a [Visual Context](https://help.smartling.com/hc/en-us/articles/360057484273--Overview-of-Visual-Context)
+    to Smartling after a Job is synced, you need to provide a way to get hold
+    of the appropriate URL for the page to use context. You provide this via
+    the `VISUAL_CONTEXT_CALLBACK` setting.
+
+    If this callback is defined, it will be used to send the visual context to Smartling.
+    This step happens just after the regular sync of a Job to Smartling and _only_ if
+    the callback is defined.
+
+    The callback must take the Job instance and return:
+
+    1. a URL for the page that shows the content used to generate that Job
+    2. the HTML of the page.
+
+    ```python
+    from wagtail_localize.models import Job
+
+    def get_visual_context(job: Job) -> tuple[str, str]:
+
+        # This assumes the page is live and visible. If the page is a draft, you
+        # will need a some custom work to expose the draft version of the page
+        page = job.translation_source.get_source_instance()
+        page_url = page.url
+
+        html = # code to render that page instance
+
+        return page_url, html
+    ```
 
 4. Run migrations:
 

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 5, 0)
+VERSION = (0, 6, 0)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/api/client.py
+++ b/src/wagtail_localize_smartling/api/client.py
@@ -404,13 +404,12 @@ class SmartlingAPIClient:
                 },
             }
 
-            file_payload: dict[tuple[str, str]] = {
+            file_payload: dict[str, tuple[str, bytes, str]] = {
                 "content": (url.split("/")[-1], html, "text/html"),
             }
 
             logger.info(
-                "Sending visual context to Smartling for Job %s/%s for URL %s",
-                job.id,
+                "Sending visual context to Smartling for Job %s for URL %s",
                 job.translation_job_uid,
                 url,
             )

--- a/src/wagtail_localize_smartling/api/serializers.py
+++ b/src/wagtail_localize_smartling/api/serializers.py
@@ -249,3 +249,7 @@ class UploadFileResponseSerializer(ResponseSerializer):
 class AddFileToJobResponseSerializer(ResponseSerializer):
     failCount = serializers.IntegerField()
     successCount = serializers.IntegerField()
+
+
+class AddVisualContextToJobSerializer(ResponseSerializer):
+    processUid = serializers.CharField()

--- a/src/wagtail_localize_smartling/api/types.py
+++ b/src/wagtail_localize_smartling/api/types.py
@@ -104,3 +104,7 @@ class SourceFileData(TypedDict):
 class GetJobDetailsResponseData(CreateJobResponseData):
     priority: int | None
     sourceFiles: list[SourceFileData]
+
+
+class AddVisualContextToJobResponseData(TypedDict):
+    processUid: str

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -13,6 +13,8 @@ from django.utils.module_loading import import_string
 if TYPE_CHECKING:
     from wagtail_localize.models import Translation, TranslationSource
 
+    from wagtail_localize_smartling.models import Job
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,7 +36,7 @@ class SmartlingSettings:
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
-    VISUAL_CONTEXT_CALLBACK: Callable[[int], tuple[str, str]] | None = None
+    VISUAL_CONTEXT_CALLBACK: Callable[["Job"], tuple[str, str]] | None = None
 
 
 def _init_settings() -> SmartlingSettings:

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -34,6 +34,7 @@ class SmartlingSettings:
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
+    VISUAL_CONTEXT_CALLBACK: Callable[[int], tuple[str, str]] | None = None
 
 
 def _init_settings() -> SmartlingSettings:
@@ -146,6 +147,14 @@ def _init_settings() -> SmartlingSettings:
 
         if callable(func_or_path):
             settings_kwargs["JOB_DESCRIPTION_CALLBACK"] = func_or_path
+
+    if "VISUAL_CONTEXT_CALLBACK" in settings_dict:
+        func_or_path = settings_dict["VISUAL_CONTEXT_CALLBACK"]
+        if isinstance(func_or_path, str):
+            func_or_path = import_string(func_or_path)
+
+        if callable(func_or_path):
+            settings_kwargs["VISUAL_CONTEXT_CALLBACK"] = func_or_path
 
     return SmartlingSettings(**settings_kwargs)
 

--- a/src/wagtail_localize_smartling/sync.py
+++ b/src/wagtail_localize_smartling/sync.py
@@ -71,6 +71,8 @@ def _initial_sync(job: "Job") -> None:
     """
     For jobs that have never been synced before, create the job in Smartling and
     add the PO file from the TranslationSource.
+
+    Also add Visual Context for Smartling CAT, if a callback to get that is configured
     """
     logger.info("Performing initial sync for job %s", job)
 
@@ -107,6 +109,9 @@ def _initial_sync(job: "Job") -> None:
 
     # Add the PO file to the job using the previously-saved URI
     client.add_file_to_job(job=job)
+
+    # Add context to the job (if settings.VISUAL_CONTEXT_CALLBACK is defined)
+    client.add_html_context_to_job(job=job)
 
 
 def _sync(job: "Job") -> None:

--- a/src/wagtail_localize_smartling/utils.py
+++ b/src/wagtail_localize_smartling/utils.py
@@ -111,7 +111,6 @@ def get_wagtail_source_locale(project: "Project") -> Locale | None:
     return locale
 
 
-# TODO test
 def suggest_source_locale(project: "Project") -> tuple[str, str] | None:
     """
     Return a tuple of language code and label for a suggested Locale from
@@ -145,16 +144,19 @@ def compute_content_hash(pofile: "POFile") -> str:
 
 def get_filename_for_visual_context(url: str, max_length: int = 256) -> str:
     """
-    Turn the given url into a long slug, based on the hostname and the path
+    Turn the given url into a long sluglike HTML filename, based
+    on the hostname and the path
     """
     if not url:
         return url
 
     _parsed = urlparse(url)
+
     _hostname = _parsed.hostname or ""
     _path = _parsed.path or ""
 
     head = "-".join(_hostname.split(".")).rstrip("-").lower()
     tail = "-".join(_path.split("/")).rstrip("-").lower()
-    trimmed = f"{head}{tail}"[: max_length - 5]
-    return f"{trimmed}.html"
+    body = f"{head}{tail}"[: max_length - 5]
+
+    return f"{body}.html"

--- a/src/wagtail_localize_smartling/utils.py
+++ b/src/wagtail_localize_smartling/utils.py
@@ -151,7 +151,10 @@ def get_filename_for_visual_context(url: str, max_length: int = 256) -> str:
         return url
 
     _parsed = urlparse(url)
-    head = "-".join(_parsed.hostname.split(".")).rstrip("-").lower()
-    tail = "-".join(_parsed.path.split("/")).rstrip("-").lower()
+    _hostname = _parsed.hostname or ""
+    _path = _parsed.path or ""
+
+    head = "-".join(_hostname.split(".")).rstrip("-").lower()
+    tail = "-".join(_path.split("/")).rstrip("-").lower()
     trimmed = f"{head}{tail}"[: max_length - 5]
     return f"{trimmed}.html"

--- a/src/wagtail_localize_smartling/utils.py
+++ b/src/wagtail_localize_smartling/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 
 from typing import TYPE_CHECKING
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urljoin, urlparse
 
 from wagtail.coreutils import (
     get_content_languages,
@@ -141,3 +141,17 @@ def compute_content_hash(pofile: "POFile") -> str:
         strings.append(f"{entry.msgctxt}: {entry.msgid}")
 
     return hashlib.sha256("".join(strings).encode()).hexdigest()
+
+
+def get_filename_for_visual_context(url: str, max_length: int = 256) -> str:
+    """
+    Turn the given url into a long slug, based on the hostname and the path
+    """
+    if not url:
+        return url
+
+    _parsed = urlparse(url)
+    head = "-".join(_parsed.hostname.split(".")).rstrip("-").lower()
+    tail = "-".join(_parsed.path.split("/")).rstrip("-").lower()
+    trimmed = f"{head}{tail}"[: max_length - 5]
+    return f"{trimmed}.html"

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -215,3 +215,7 @@ def map_project_locale_to_smartling(locale: str) -> str:
 
 def job_description_callback(description: str, translation_source, translations) -> str:
     return "1337"
+
+
+def visual_context_callback(job_id: int) -> tuple[str, str]:
+    return "https://example.com/path/to/page/", "<html><body>test</body></html>"

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -9,8 +9,13 @@ https://docs.djangoproject.com/en/stable/ref/settings/
 """
 
 import os
+import typing
 
 import dj_database_url
+
+
+if typing.TYPE_CHECKING:
+    from wagtail_localize_smartling.models import Job
 
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
@@ -217,5 +222,5 @@ def job_description_callback(description: str, translation_source, translations)
     return "1337"
 
 
-def visual_context_callback(job_id: int) -> tuple[str, str]:
+def visual_context_callback(job: "Job") -> tuple[str, str]:
     return "https://example.com/path/to/page/", "<html><body>test</body></html>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from wagtail_localize.models import LocaleSynchronization
 
 from wagtail_localize_smartling.api.client import client
 from wagtail_localize_smartling.api.types import (
+    AddVisualContextToJobResponseData,
     AuthenticateResponseData,
     GetProjectDetailsResponseData,
     TargetLocaleData,
@@ -144,6 +145,56 @@ def smartling_project(responses, settings, smartling_auth):
     # Reset Project.get_current() cache so the response always gets consumed
     Project.get_current.cache_clear()
     return Project.get_current()
+
+
+@pytest.fixture()
+def smartling_add_visual_context(responses, settings, smartling_auth):
+    # Mock API request for sending visual context
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    responses.assert_all_requests_are_fired = False
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/context-api/v2/projects/{quote(project_id)}/contexts/upload-and-match-async",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "SUCCESS",
+                    "data": AddVisualContextToJobResponseData(
+                        processUid="dummy_process_uid",
+                    ),
+                },
+            }
+        ),
+    )
+
+    return "dummy_process_uid"
+
+
+@pytest.fixture()
+def smartling_add_visual_context__error_response(responses, settings, smartling_auth):
+    # Mock API request for sending visual context
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    responses.assert_all_requests_are_fired = False
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/context-api/v2/projects/{quote(project_id)}/contexts/upload-and-match-async",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "VALIDATION_ERROR",
+                    "data": [
+                        {
+                            "key": "some key",
+                            "message": "some message",
+                            "details": "some details",
+                        }
+                    ],
+                },
+            }
+        ),
+    )
+
+    return "dummy_process_uid"
 
 
 @pytest.fixture

--- a/tests/management_commands/test_sync_smartling.py
+++ b/tests/management_commands/test_sync_smartling.py
@@ -6,7 +6,7 @@ from testapp.factories import InfoPageFactory
 from tests.factories import JobFactory
 
 
-@pytest.mark.skip()
+@pytest.mark.skip("WRITE ME")
 @pytest.mark.django_db()
 def test_sync_smartling(smartling_project):
     unsynced_job_page = InfoPageFactory()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,114 @@
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+import pytest
+
+from wagtail_localize_smartling.api.client import InvalidResponse, client
+
+
+if TYPE_CHECKING:
+    from wagtail_localize_smartling.models import Job
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__get_project_details():
+    assert False
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__create_job():
+    assert False
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__list_jobs():
+    assert False
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__get_job_details():
+    assert False
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__upload_po_file_for_job():
+    assert False
+
+
+@pytest.mark.skip("WRITE ME")
+def test_client__download_translations():
+    assert False
+
+
+@pytest.mark.parametrize("bootstrap_callback", (True, False))
+def test_client__add_html_context_to_job__depends_on_callback_availability(
+    bootstrap_callback,
+    smartling_job: "Job",
+    smartling_settings,
+    smartling_add_visual_context,
+):
+    callback_func = Mock(
+        name="fake callback",
+        return_value=(
+            "https://example.com/path/to/page/",
+            "<html><body>test</body></html>",
+        ),
+    )
+
+    if bootstrap_callback:
+        smartling_settings.VISUAL_CONTEXT_CALLBACK = callback_func
+
+    client.add_html_context_to_job(job=smartling_job)
+
+    if bootstrap_callback:
+        callback_func.assert_called_once_with(smartling_job)
+    else:
+        assert not callback_func.called
+
+
+def test_client__add_html_context_to_job__happy_path(
+    smartling_job: "Job",
+    smartling_settings,
+    smartling_add_visual_context,
+):
+    # Very similar to test_client__add_html_context_to_job__depends_on_callback_availability
+    # but separate for regression-protection value
+    callback_func = Mock(
+        name="fake callback",
+        return_value=(
+            "https://example.com/path/to/page/",
+            "<html><body>test</body></html>",
+        ),
+    )
+
+    smartling_settings.VISUAL_CONTEXT_CALLBACK = callback_func
+    resp = client.add_html_context_to_job(job=smartling_job)
+    callback_func.assert_called_once_with(smartling_job)
+    assert resp == {"processUid": "dummy_process_uid"}
+
+
+def test_client__add_html_context_to_job__error_path(
+    smartling_job: "Job",
+    smartling_settings,
+    smartling_add_visual_context__error_response,
+):
+    callback_func = Mock(
+        name="fake callback",
+        return_value=(
+            "https://example.com/path/to/page/",
+            "<html><body>test</body></html>",
+        ),
+    )
+
+    smartling_settings.VISUAL_CONTEXT_CALLBACK = callback_func
+
+    with pytest.raises(InvalidResponse) as exc:
+        client.add_html_context_to_job(job=smartling_job)
+
+    assert exc.value.args == (
+        "Response did not match expected format: {'response': {'code': 'VALIDATION_ERROR', 'data': [{'key': 'some key', 'message': 'some message', 'details': 'some details'}]}}",  # noqa: E501
+    )
+
+    callback_func.assert_called_once_with(smartling_job)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -143,3 +143,31 @@ def test_job_description_callback():
 def test_invalid_job_description_callback_signature():
     smartling_settings = _init_settings()
     assert smartling_settings.JOB_DESCRIPTION_CALLBACK is None
+
+
+@override_settings(
+    WAGTAIL_LOCALIZE_SMARTLING={
+        **REQUIRED_SETTINGS,
+        "VISUAL_CONTEXT_CALLBACK": "testapp.settings.visual_context_callback",
+    }
+)
+def test_visual_context_callback():
+    smartling_settings = _init_settings()
+    fn = smartling_settings.VISUAL_CONTEXT_CALLBACK
+    assert callable(fn)
+    assert fn.__name__ == "visual_context_callback"
+    assert fn(123) == (
+        "https://example.com/path/to/page/",
+        "<html><body>test</body></html>",
+    )
+
+
+@override_settings(
+    WAGTAIL_LOCALIZE_SMARTLING={
+        **REQUIRED_SETTINGS,
+        "VISUAL_CONTEXT_CALLBACK": 123,
+    }
+)
+def test_invalid_visual_context_callback_signature():
+    smartling_settings = _init_settings()
+    assert smartling_settings.VISUAL_CONTEXT_CALLBACK is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -151,12 +151,12 @@ def test_invalid_job_description_callback_signature():
         "VISUAL_CONTEXT_CALLBACK": "testapp.settings.visual_context_callback",
     }
 )
-def test_visual_context_callback():
+def test_visual_context_callback(smartling_job):
     smartling_settings = _init_settings()
     fn = smartling_settings.VISUAL_CONTEXT_CALLBACK
     assert callable(fn)
     assert fn.__name__ == "visual_context_callback"
-    assert fn(123) == (
+    assert fn(smartling_job) == (
         "https://example.com/path/to/page/",
         "<html><body>test</body></html>",
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,28 @@ def test_format_wagtail_locale_id(locale_id, expected, reformat, smartling_setti
         "fr-FR": "FR",
     }
     assert utils.format_wagtail_locale_id(locale_id) == expected
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    (
+        ("https://example.com/test/path/here", "example-com-test-path-here.html"),
+        ("https://example.com/test/path/here/", "example-com-test-path-here.html"),
+        ("https://www.example.com/test/", "www-example-com-test.html"),
+        (
+            "https://example.com/fr-CA/test/path/to/a/page/here",
+            "example-com-fr-ca-test-path-to-a-page-here.html",
+        ),
+        ("", ""),
+        ("https://example.com/", "example-com.html"),
+        (
+            "https://example.com/test/path/here" + "/here" * 60,  # well over 300 chars
+            "example-com-test-path-here"
+            + "-here" * 45
+            + ".html",  # 26 + 45*5 + 5 = 256 chars == func's default max_length
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_get_filename_for_visual_context(url, expected):
+    assert utils.get_filename_for_visual_context(url) == expected


### PR DESCRIPTION
This changeset adds support for translators to use Smartling's live-preview Computer-Aided-Translation tool for a given Smartling Job.

The `wagtail_localize_smartling.client` gains a method to hit Smartling's "Upload new context and trigger matching" API endpoint ([docs here](https://api-reference.smartling.com/#tag/Context/operation/uploadAndMatchVisualContext))

The new method gets appropriate payload needed (the page's URL and its rendered HTML) via a new setting called `VISUAL_CONTEXT_CALLBACK` 

---

Resolves #34
Resolves #31 