### PR TITLE
Do not fail when syncing objects that do not have a visual context

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ integrates with the Smartling translation platform.
 
         content_obj = job.translation_source.get_source_instance()
 
-        # IMPORTANT: if your translatable objets include some where a visual
+        # IMPORTANT: if your translatable objects include some where a visual
         # context is not available or appropriate (eg a Snippet, rather than
         # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
         # raise IncapableVisualContextCallback with an explaination

--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ integrates with the Smartling translation platform.
         content_obj = job.translation_source.get_source_instance()
 
         # IMPORTANT: if your translatable objects include some where a visual
-        # context is not available or appropriate (eg a Snippet, rather than
-        # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
-        # raise IncapableVisualContextCallback with an explaination
+        # context is not available via a standalone, public URL (eg a Snippet,
+        # rather than a Page), then your settings.VISUAL_CONTEXT_CALLBACK function
+        # should raise IncapableVisualContextCallback with an explaination.
+
+        # Below, we check if the object is a Page, but depending on how your objects
+        # are previewable, you could use isinstance(content_obj, PreviewableMixin)
 
         if not isinstance(content_obj, Page):
             raise IncapableVisualContextCallback(

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ integrates with the Smartling translation platform.
         html = # code to render that page instance
 
         return page_url, html
+
+        # IMPORTANT: if your translatable objets include some where a visual
+        # context is not available or appropriate (eg a Snippet, rather than
+        # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
+        # return a tuple of (None, None) to signify no visual context is available
+
     ```
 
     Note that if the syncing of the visual context fails, this will break the

--- a/README.md
+++ b/README.md
@@ -144,23 +144,34 @@ integrates with the Smartling translation platform.
     2. the HTML of the page.
 
     ```python
+
+    from wagtail.models import Page
     from wagtail_localize.models import Job
+    from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 
     def get_visual_context(job: Job) -> tuple[str, str]:
 
-        # This assumes the page is live and visible. If the page is a draft, you
-        # will need a some custom work to expose the draft version of the page
-        page = job.translation_source.get_source_instance()
+        # This assumes the page is live and visible. If the page is a
+        # draft, you will need a some custom work to expose the draft
+        # version of the page
+
+        content_obj = job.translation_source.get_source_instance()
+
+        # IMPORTANT: if your translatable objets include some where a visual
+        # context is not available or appropriate (eg a Snippet, rather than
+        # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
+        # raise IncapableVisualContextCallback with an explaination
+
+        if not isinstance(content_obj, Page):
+            raise IncapableVisualContextCallback(
+                "Object was not visually previewable"
+            )
+
         page_url = page.full_url
 
         html = # code to render that page instance
 
         return page_url, html
-
-        # IMPORTANT: if your translatable objets include some where a visual
-        # context is not available or appropriate (eg a Snippet, rather than
-        # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
-        # return a tuple of (None, None) to signify no visual context is available
 
     ```
 

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 6, 0)
+VERSION = (0, 6, 1)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/api/client.py
+++ b/src/wagtail_localize_smartling/api/client.py
@@ -428,6 +428,10 @@ class SmartlingAPIClient:
                 # context is not available or appropriate (eg a Snippet, rather than
                 # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
                 # raise IncapableVisualContextCallback with an explaination
+                #
+                # Below, we simply check if the object is a Page, but depending
+                # on how your objects are previewable, you could instead use
+                # isinstance(content_obj, PreviewableMixin)
 
                 if not isinstance(content_obj, Page):
                     raise IncapableVisualContextCallback(

--- a/src/wagtail_localize_smartling/api/client.py
+++ b/src/wagtail_localize_smartling/api/client.py
@@ -424,7 +424,7 @@ class SmartlingAPIClient:
 
                 content_obj = job.translation_source.get_source_instance()
 
-                # IMPORTANT: if your translatable objets include some where a visual
+                # IMPORTANT: if your translatable objects include some where a visual
                 # context is not available or appropriate (eg a Snippet, rather than
                 # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
                 # raise IncapableVisualContextCallback with an explaination

--- a/src/wagtail_localize_smartling/api/client.py
+++ b/src/wagtail_localize_smartling/api/client.py
@@ -26,6 +26,7 @@ from django.utils.functional import SimpleLazyObject
 from requests.exceptions import HTTPError
 
 from .. import utils
+from ..exceptions import IncapableVisualContextCallback
 from ..settings import settings as smartling_settings
 from . import types
 from .serializers import (
@@ -411,7 +412,9 @@ class SmartlingAPIClient:
 
         e.g.
 
+            from wagtail.models import Page
             from wagtail_localize.models import Job
+            from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 
             def get_visual_context(job: Job) -> tuple[str, str]:
 
@@ -419,17 +422,24 @@ class SmartlingAPIClient:
                 # draft, you will need a some custom work to expose the draft
                 # version of the page
 
-                page = job.translation_source.get_source_instance()
+                content_obj = job.translation_source.get_source_instance()
+
+                # IMPORTANT: if your translatable objets include some where a visual
+                # context is not available or appropriate (eg a Snippet, rather than
+                # a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
+                # raise IncapableVisualContextCallback with an explaination
+
+                if not isinstance(content_obj, Page):
+                    raise IncapableVisualContextCallback(
+                        "Object was not visually previewable"
+                    )
+
                 page_url = page.full_url
 
                 html = # code to render that page instance
 
                 return page_url, html
 
-        IMPORTANT: if your translatable objets include some where a visual
-        context is not available or appropriate (eg a Snippet, rather than
-        a Page), then your settings.VISUAL_CONTEXT_CALLBACK function should
-        return a tuple of (None, None) to signify no visual context is available
         """
 
         if not (
@@ -438,13 +448,12 @@ class SmartlingAPIClient:
             logger.info("No visual context callback configured")
             return
 
-        url, html = visual_context_callback_fn(job)
-
-        if not url or not html:
-            # Not all jobs will be for objects that have a viable visual context
+        try:
+            url, html = visual_context_callback_fn(job)
+        except IncapableVisualContextCallback as ex:
             logger.info(
-                "Visual context callback didn't return viable values. "
-                f"url: {bool(url)} and html: {bool(html)}"
+                "Visual context callback refused to provide values. "
+                f"Reason: {str(ex)}. Not sending visual context."
             )
             return
 

--- a/src/wagtail_localize_smartling/exceptions.py
+++ b/src/wagtail_localize_smartling/exceptions.py
@@ -1,0 +1,7 @@
+class IncapableVisualContextCallback(Exception):
+    """
+    To be raised by the settings.VISUAL_CONTEXT_CALLBACK func
+    if it cannot provide the appropriate values.
+    """
+
+    pass

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -36,7 +36,9 @@ class SmartlingSettings:
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
-    VISUAL_CONTEXT_CALLBACK: Callable[["Job"], tuple[str, str]] | None = None
+    VISUAL_CONTEXT_CALLBACK: (
+        Callable[["Job"], tuple[str, str] | tuple[bool, bool]] | None
+    ) = None
 
 
 def _init_settings() -> SmartlingSettings:

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -36,7 +36,7 @@ class SmartlingSettings:
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
-    VISUAL_CONTEXT_CALLBACK: Callable[["Job"], tuple[str, str] | None] = None
+    VISUAL_CONTEXT_CALLBACK: Callable[["Job"], tuple[str, str]] | None = None
 
 
 def _init_settings() -> SmartlingSettings:

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -36,9 +36,7 @@ class SmartlingSettings:
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
-    VISUAL_CONTEXT_CALLBACK: (
-        Callable[["Job"], tuple[str, str] | tuple[bool, bool]] | None
-    ) = None
+    VISUAL_CONTEXT_CALLBACK: Callable[["Job"], tuple[str, str] | None] = None
 
 
 def _init_settings() -> SmartlingSettings:

--- a/src/wagtail_localize_smartling/sync.py
+++ b/src/wagtail_localize_smartling/sync.py
@@ -184,7 +184,7 @@ def _download_and_apply_translations(job: "Job") -> None:
                     target_locale__language_code=wagtail_locale_id
                 )
             except job.translations.model.DoesNotExist:
-                logger.error(
+                logger.info(
                     "Translation not found for locale %s, skipping", wagtail_locale_id
                 )
                 continue

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -14,32 +14,32 @@ pytestmark = pytest.mark.django_db
 
 @pytest.mark.skip("WRITE ME")
 def test_client__get_project_details():
-    assert False
+    pass
 
 
 @pytest.mark.skip("WRITE ME")
 def test_client__create_job():
-    assert False
+    pass
 
 
 @pytest.mark.skip("WRITE ME")
 def test_client__list_jobs():
-    assert False
+    pass
 
 
 @pytest.mark.skip("WRITE ME")
 def test_client__get_job_details():
-    assert False
+    pass
 
 
 @pytest.mark.skip("WRITE ME")
 def test_client__upload_po_file_for_job():
-    assert False
+    pass
 
 
 @pytest.mark.skip("WRITE ME")
 def test_client__download_translations():
-    assert False
+    pass
 
 
 @pytest.mark.parametrize("bootstrap_callback", (True, False))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,11 +89,28 @@ def test_client__add_html_context_to_job__happy_path(
     assert resp == {"processUid": "dummy_process_uid"}
 
 
+def test_client__add_html_context_to_job__callback_does_not_provide_visual_context_data(
+    smartling_job: "Job",
+    smartling_settings,
+    smartling_add_visual_context,
+):
+    callback_func = Mock(
+        name="fake callback",
+        return_value=(False, False),
+    )
+
+    smartling_settings.VISUAL_CONTEXT_CALLBACK = callback_func
+    resp = client.add_html_context_to_job(job=smartling_job)
+    callback_func.assert_called_once_with(smartling_job)
+    assert resp is None
+
+
 def test_client__add_html_context_to_job__error_path(
     smartling_job: "Job",
     smartling_settings,
     smartling_add_visual_context__error_response,
 ):
+    # Fake a validation error using the smartling_add_visual_context__error_response fixture
     callback_func = Mock(
         name="fake callback",
         return_value=(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from wagtail_localize_smartling.api.client import InvalidResponse, client
+from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 
 
 if TYPE_CHECKING:
@@ -96,7 +97,7 @@ def test_client__add_html_context_to_job__callback_does_not_provide_visual_conte
 ):
     callback_func = Mock(
         name="fake callback",
-        return_value=(False, False),
+        side_effect=IncapableVisualContextCallback("Testing!"),
     )
 
     smartling_settings.VISUAL_CONTEXT_CALLBACK = callback_func


### PR DESCRIPTION
In #35 we forgot an angle: while Pages can be used to generate the URL and HTML needed for Smartling's CAT Visual Context, there are other CMS objects – specifically Snippets – that may be sent for translation (because they are FKed from the Page) but which have no visual representation of their own.

This changeset handles that by using `Exception` based control flow in the custom callback function.

Resolves #40 