### PR TITLE
Improve default job name and description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     "dj-database-url==2.1.0",
     "django-stubs",
     "djangorestframework-stubs",
+    "freezegun==1.5.1",
     "pre-commit==3.4.0",
     "pyright==1.1.375",
     "pytest-cov==5.0.0",

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 6, 1)
+VERSION = (0, 7, 0)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/models.py
+++ b/src/wagtail_localize_smartling/models.py
@@ -293,17 +293,8 @@ class Job(SyncedModel):
         """
         source_instance = translation_source.get_source_instance()
         ct_name = type(source_instance)._meta.verbose_name
-        edit_url = urljoin(
-            get_admin_base_url() or "",
-            translation_source.get_source_instance_edit_url(),
-        )
 
-        description = (
-            "Automatically-created Wagtail translation job for "
-            f"{ct_name} "
-            f'"{source_instance}". '
-            f"The source content can be edited here: {edit_url}"
-        )
+        description = f"CMS translation job for {ct_name} '{source_instance}'."
 
         if callback_fn := smartling_settings.JOB_DESCRIPTION_CALLBACK:
             description = callback_fn(description, source_instance, translations)

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -33,7 +33,7 @@ class SmartlingSettings:
         default_factory=dict
     )
     REFORMAT_LANGUAGE_CODES: bool = True
-    JOB_NAME_PREFIX: str = None
+    JOB_NAME_PREFIX: str | None = None
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None

--- a/src/wagtail_localize_smartling/settings.py
+++ b/src/wagtail_localize_smartling/settings.py
@@ -33,6 +33,7 @@ class SmartlingSettings:
         default_factory=dict
     )
     REFORMAT_LANGUAGE_CODES: bool = True
+    JOB_NAME_PREFIX: str = None
     JOB_DESCRIPTION_CALLBACK: (
         Callable[[str, "TranslationSource", Iterable["Translation"]], str] | None
     ) = None
@@ -157,6 +158,9 @@ def _init_settings() -> SmartlingSettings:
 
         if callable(func_or_path):
             settings_kwargs["VISUAL_CONTEXT_CALLBACK"] = func_or_path
+
+    if "JOB_NAME_PREFIX" in settings_dict:
+        settings_kwargs["JOB_NAME_PREFIX"] = settings_dict["JOB_NAME_PREFIX"]
 
     return SmartlingSettings(**settings_kwargs)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,8 +3,14 @@ from urllib.parse import urljoin
 
 import pytest
 
+from freezegun import freeze_time
 from wagtail.admin.utils import get_admin_base_url
+from wagtail.models import Locale
+from wagtail_localize.models import Translation, TranslationSource
 
+from wagtail_localize_smartling.models import Job
+
+from testapp.factories import InfoPageFactory
 from testapp.settings import job_description_callback
 
 
@@ -32,3 +38,27 @@ def test_job_description_callback(smartling_job: "Job", smartling_settings):
         smartling_job.translation_source, smartling_job.translations.all()
     )
     assert description == "1337"
+
+
+@pytest.mark.parametrize("name_prefix", (None, "Test prefix 123"))
+@freeze_time("2024-05-03 12:34:56.123456")
+def test_Job_get_default_name(name_prefix, smartling_settings, root_page):
+    page = InfoPageFactory(parent=root_page, title="Component test page")
+    translation_source, created = TranslationSource.get_or_create_from_instance(page)
+    page_translation = Translation.objects.create(
+        source=translation_source,
+        target_locale=Locale.objects.get(language_code="fr"),
+    )
+
+    smartling_settings.JOB_NAME_PREFIX = name_prefix
+
+    name = Job.get_default_name(translation_source, [page_translation])
+
+    expected_name = (
+        f"{str(translation_source.object.translation_key).split('-')[0]}:"
+        "1:fr:2024-05-03T12:34:56"
+    )
+    if name_prefix:
+        expected_name = f"{name_prefix}:" + expected_name
+
+    assert expected_name == name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,14 +22,7 @@ pytestmark = pytest.mark.django_db
 
 def test_default_job_description(smartling_job: "Job"):
     page = smartling_job.translation_source.get_source_instance()
-    url = urljoin(
-        get_admin_base_url() or "",
-        smartling_job.translation_source.get_source_instance_edit_url(),
-    )
-    assert smartling_job.description == (
-        f'Automatically-created Wagtail translation job for info page "{page}". '
-        f"The source content can be edited here: {url}"
-    )
+    assert smartling_job.description == f"CMS translation job for info page '{page}'."
 
 
 def test_job_description_callback(smartling_job: "Job", smartling_settings):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,7 +49,7 @@ def test_Job_get_default_name(name_prefix, smartling_settings, root_page):
 
     expected_name = (
         f"{str(translation_source.object.translation_key).split('-')[0]}:"
-        "1:fr:2024-05-03T12:34:56"
+        f"{translation_source.pk}:fr:2024-05-03T12:34:56"
     )
     if name_prefix:
         expected_name = f"{name_prefix}:" + expected_name


### PR DESCRIPTION
* Make the default job name simpler/shorter and support a custom, project-level prefix via settings -- resolves #36 

* Simplify default Job description sent to Smartling  -- resolves #42 

     The Wagtail Admin URL isn't particularly useful to a translator, and if it were needed, a project could add it via the custom job description callback
     
* Prep 0.7.0 release