### PR TITLE
Amend how we upload .po files to avoid "File Locked" API error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "djangorestframework-stubs",
     "freezegun==1.5.1",
     "pre-commit==3.4.0",
-    "pyright==1.1.375",
+    "pyright==1.1.390",
     "pytest-cov==5.0.0",
     "pytest-django==4.8.0",
     "pytest-responses==0.5.1",

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 7, 0)
+VERSION = (0, 8, 0)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/api/client.py
+++ b/src/wagtail_localize_smartling/api/client.py
@@ -30,7 +30,6 @@ from ..exceptions import IncapableVisualContextCallback
 from ..settings import settings as smartling_settings
 from . import types
 from .serializers import (
-    AddFileToJobResponseSerializer,
     AddVisualContextToJobSerializer,
     AuthenticateResponseSerializer,
     CreateBatchResponseSerializer,
@@ -41,7 +40,6 @@ from .serializers import (
     NullDataResponseSerializer,
     RefreshAccessTokenResponseSerializer,
     ResponseSerializer,
-    UploadFileResponseSerializer,
     UploadFileToBatchResponseSerializer,
 )
 

--- a/src/wagtail_localize_smartling/api/serializers.py
+++ b/src/wagtail_localize_smartling/api/serializers.py
@@ -257,19 +257,6 @@ class GetJobDetailsResponseSerializer(CreateJobResponseSerializer):
     sourceFiles = serializers.ListField(child=SourceFileSerializer())
 
 
-# TODO: Remove me. Deprecated in favour of Batches
-class UploadFileResponseSerializer(ResponseSerializer):
-    overWritten = serializers.BooleanField()
-    stringCount = serializers.IntegerField()
-    wordCount = serializers.IntegerField()
-
-
-# TODO: Remove me. Deprecated in favour of Batches
-class AddFileToJobResponseSerializer(ResponseSerializer):
-    failCount = serializers.IntegerField()
-    successCount = serializers.IntegerField()
-
-
 class AddVisualContextToJobSerializer(ResponseSerializer):
     # https://api-reference.smartling.com/#tag/Context/operation/uploadAndMatchVisualContext
     processUid = serializers.CharField()

--- a/src/wagtail_localize_smartling/api/serializers.py
+++ b/src/wagtail_localize_smartling/api/serializers.py
@@ -140,6 +140,12 @@ class ResponseSerializer(
 
 
 class NullDataResponseSerializer(ResponseSerializer):
+    _acceptable_codes_for_null_response = [
+        # Subclasses should define what are acceptable response messages
+        # based on the use-case. e.g.
+        # "ACCEPTED",
+    ]
+
     def validate_empty_values(self, data) -> tuple[bool, Any]:
         """
         Overrides the default behavior to allow `None` for the `data` field.

--- a/src/wagtail_localize_smartling/api/serializers.py
+++ b/src/wagtail_localize_smartling/api/serializers.py
@@ -153,7 +153,7 @@ class NullDataResponseSerializer(ResponseSerializer):
         if "response" in data and (
             data["response"]["data"] is None
             and hasattr(self, "_acceptable_codes_for_null_response")
-            and data["response"]["code"] in self._acceptable_codes_for_null_response  # pyright: ignore [reportAttributeAccessIssue]
+            and data["response"]["code"] in self._acceptable_codes_for_null_response
         ):
             # Consider this as valid for the serializer
             return True, data

--- a/src/wagtail_localize_smartling/api/types.py
+++ b/src/wagtail_localize_smartling/api/types.py
@@ -108,3 +108,11 @@ class GetJobDetailsResponseData(CreateJobResponseData):
 
 class AddVisualContextToJobResponseData(TypedDict):
     processUid: str
+
+
+class CreateBatchForJobResponseData(TypedDict):
+    batchUid: str
+
+
+class UploadFileToBatchResponseData(TypedDict):
+    pass

--- a/src/wagtail_localize_smartling/models.py
+++ b/src/wagtail_localize_smartling/models.py
@@ -3,7 +3,6 @@ import logging
 from collections.abc import Iterable
 from datetime import datetime
 from functools import lru_cache
-from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
@@ -12,7 +11,6 @@ from django.db.models.manager import Manager
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel
-from wagtail.admin.utils import get_admin_base_url
 from wagtail_localize.components import register_translation_component
 from wagtail_localize.models import Translation, TranslationSource
 from wagtail_localize.tasks import ImmediateBackend, background

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,10 @@ from wagtail_localize_smartling.api.client import client
 from wagtail_localize_smartling.api.types import (
     AddVisualContextToJobResponseData,
     AuthenticateResponseData,
+    CreateBatchForJobResponseData,
     GetProjectDetailsResponseData,
     TargetLocaleData,
+    UploadFileToBatchResponseData,
 )
 from wagtail_localize_smartling.models import Project
 
@@ -192,6 +194,99 @@ def smartling_add_visual_context__error_response(responses, settings, smartling_
         ),
     )
 
+
+@pytest.fixture()
+def smartling_create_batch_for_job(responses, settings, smartling_auth):
+    # Mock API request for creating a batch
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/job-batches-api/v2/projects/{quote(project_id)}/batches",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "SUCCESS",
+                    "data": CreateBatchForJobResponseData(
+                        batchUid="dummy_batch_uid",
+                    ),
+                },
+            }
+        ),
+    )
+
+
+@pytest.fixture()
+def smartling_create_batch_for_job__error_response(responses, settings, smartling_auth):
+    # Mock API request for creating a batch
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/job-batches-api/v2/projects/{quote(project_id)}/batches",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "VALIDATION_ERROR",
+                    "data": [
+                        {
+                            "key": "some batch key",
+                            "message": "some batch message",
+                            "details": "some batch details",
+                        }
+                    ],
+                },
+            }
+        ),
+    )
+
+
+@pytest.fixture()
+def smartling_upload_files_to_job_batch(responses, settings, smartling_auth):
+    # Mock API request for uploading a file to a batch
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    batch_uid = "test-batch-uid"
+    responses.assert_all_requests_are_fired = False
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/job-batches-api/v2/projects/{quote(project_id)}/batches/{batch_uid}/file",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "ACCEPTED",
+                    "data": UploadFileToBatchResponseData(),
+                },
+            }
+        ),
+        status=202,
+    )
+
+
+@pytest.fixture()
+def smartling_upload_files_to_job_batch__error_response(
+    responses, settings, smartling_auth
+):
+    # Mock API request for uploading a file to a batch
+    project_id = settings.WAGTAIL_LOCALIZE_SMARTLING["PROJECT_ID"]
+    batch_uid = "test-batch-uid"
+    responses.assert_all_requests_are_fired = False
+    responses.add(
+        method="POST",
+        url=f"https://api.smartling.com/job-batches-api/v2/projects/{quote(project_id)}/batches/{batch_uid}/file",
+        body=json.dumps(
+            {
+                "response": {
+                    "code": "VALIDATION_ERROR",
+                    "data": [
+                        {
+                            "key": "some upload key",
+                            "message": "some upload message",
+                            "details": "some upload details",
+                        }
+                    ],
+                },
+            }
+        ),
+        status=202,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,7 +285,7 @@ def smartling_upload_files_to_job_batch__error_response(
                 },
             }
         ),
-        status=202,
+        status=400,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,8 +167,6 @@ def smartling_add_visual_context(responses, settings, smartling_auth):
         ),
     )
 
-    return "dummy_process_uid"
-
 
 @pytest.fixture()
 def smartling_add_visual_context__error_response(responses, settings, smartling_auth):
@@ -194,7 +192,6 @@ def smartling_add_visual_context__error_response(responses, settings, smartling_
         ),
     )
 
-    return "dummy_process_uid"
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,11 +32,6 @@ def test_client__get_job_details():
 
 
 @pytest.mark.skip("WRITE ME")
-def test_client__upload_po_file_for_job():
-    pass
-
-
-@pytest.mark.skip("WRITE ME")
 def test_client__download_translations():
     pass
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,10 +5,8 @@ import pytest
 
 from wagtail_localize_smartling.api.client import InvalidResponse, client
 from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
+from wagtail_localize_smartling.models import Job
 
-
-if TYPE_CHECKING:
-    from wagtail_localize_smartling.models import Job
 
 pytestmark = pytest.mark.django_db
 
@@ -171,5 +169,8 @@ def test_client__upload_files_to_job_batch__error_path(
     )
 
 
-def test_get_file_uri_for_job(smartling_job):
-    assert client.get_file_uri_for_job(job=smartling_job) == "job_1_ts_1.po"
+def test_get_file_uri_for_job():
+    mock_job = Mock(spec=Job)
+    mock_job.pk = 23
+    mock_job.translation_source.pk = 45
+    assert client.get_file_uri_for_job(job=mock_job) == "job_23_ts_45.po"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ def test_client__add_html_context_to_job__happy_path(
     smartling_settings,
     smartling_add_visual_context,
 ):
-    # Very similar to test_client__add_html_context_to_job__depends_on_callback_availability
+    # Very similar to test_client__add_html_context_to_job__depends_on_callback_availability  # noqa: E501
     # but separate for regression-protection value
     callback_func = Mock(
         name="fake callback",
@@ -111,7 +111,7 @@ def test_client__add_html_context_to_job__error_path(
     smartling_settings,
     smartling_add_visual_context__error_response,
 ):
-    # Fake a validation error using the smartling_add_visual_context__error_response fixture
+    # Fake a validation error using the smartling_add_visual_context__error_response fixture  # noqa: E501
     callback_func = Mock(
         name="fake callback",
         return_value=(
@@ -130,3 +130,46 @@ def test_client__add_html_context_to_job__error_path(
     )
 
     callback_func.assert_called_once_with(smartling_job)
+
+
+def test_client__create_batch_for_job__happy_path(
+    smartling_job: "Job",
+    smartling_create_batch_for_job,
+):
+    batch_uid = client.create_batch_for_job(job=smartling_job)
+    assert batch_uid == "dummy_batch_uid"
+
+
+def test_client__create_batch_for_job__error_path(
+    smartling_job: "Job",
+    smartling_create_batch_for_job__error_response,
+):
+    with pytest.raises(InvalidResponse) as exc:
+        client.create_batch_for_job(job=smartling_job)
+
+    assert exc.value.args == (
+        "Response did not match expected format: {'response': {'code': 'VALIDATION_ERROR', 'data': [{'key': 'some batch key', 'message': 'some batch message', 'details': 'some batch details'}]}}",  # noqa: E501
+    )
+
+
+def test_client__upload_files_to_job_batch__happy_path(
+    smartling_job,
+    smartling_upload_files_to_job_batch,
+):
+    client.upload_files_to_job_batch(job=smartling_job, batch_uid="test-batch-uid")
+
+
+def test_client__upload_files_to_job_batch__error_path(
+    smartling_job,
+    smartling_upload_files_to_job_batch__error_response,
+):
+    with pytest.raises(InvalidResponse) as exc:
+        client.upload_files_to_job_batch(job=smartling_job, batch_uid="test-batch-uid")
+
+    assert exc.value.args == (
+        "Response did not match expected format: {'response': {'code': 'VALIDATION_ERROR', 'data': [{'key': 'some upload key', 'message': 'some upload message', 'details': 'some upload details'}]}}",  # noqa: E501
+    )
+
+
+def test_get_file_uri_for_job(smartling_job):
+    assert client.get_file_uri_for_job(job=smartling_job) == "job_1_ts_1.po"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,8 @@
 from typing import TYPE_CHECKING
-from urllib.parse import urljoin
 
 import pytest
 
 from freezegun import freeze_time
-from wagtail.admin.utils import get_admin_base_url
 from wagtail.models import Locale
 from wagtail_localize.models import Translation, TranslationSource
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -14,7 +14,7 @@ def test_UploadFileToBatchResponseSerializer__valid():
     valid_response = {
         "response": {
             "code": "ACCEPTED",
-            "data": None,  # Note: the regular ResponseSerializer would not like this None
+            "data": None,  # The regular ResponseSerializer would not like this None
         }
     }
     serializer = UploadFileToBatchResponseSerializer(data=valid_response)
@@ -42,7 +42,7 @@ def test_UploadFileToBatchResponseSerializer__data_present():
             "code": "ACCEPTED",
             "data": {
                 "file_id": "12345"
-            },  # Unrealistic to get a value back for `data`, but possible if the API changed behaviour
+            },  # Unrealistic to get a value back for `data`, but not impossible
         }
     }
     serializer = UploadFileToBatchResponseSerializer(data=valid_response)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,65 @@
+import pytest
+
+from rest_framework.exceptions import ValidationError
+
+from wagtail_localize_smartling.api.serializers import (
+    UploadFileToBatchResponseSerializer,
+)
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_UploadFileToBatchResponseSerializer__valid():
+    valid_response = {
+        "response": {
+            "code": "ACCEPTED",
+            "data": None,  # Note: the regular ResponseSerializer would not like this None
+        }
+    }
+    serializer = UploadFileToBatchResponseSerializer(data=valid_response)
+    assert serializer.is_valid(), serializer.errors
+    validated_data = serializer.validated_data
+    assert validated_data["response"]["code"] == "ACCEPTED"
+    assert validated_data["response"]["data"] is None
+
+
+def test_UploadFileToBatchResponseSerializer__invalid_code():
+    invalid_response = {
+        "response": {
+            "code": "REJECTED",
+            "data": None,
+        }
+    }
+    serializer = UploadFileToBatchResponseSerializer(data=invalid_response)
+    with pytest.raises(ValidationError):
+        serializer.is_valid(raise_exception=True)
+
+
+def test_UploadFileToBatchResponseSerializer__data_present():
+    valid_response = {
+        "response": {
+            "code": "ACCEPTED",
+            "data": {
+                "file_id": "12345"
+            },  # Unrealistic to get a value back for `data`, but possible if the API changed behaviour
+        }
+    }
+    serializer = UploadFileToBatchResponseSerializer(data=valid_response)
+    assert serializer.is_valid(), serializer.errors
+    validated_data = serializer.validated_data
+    assert validated_data["response"]["code"] == "ACCEPTED"
+    assert validated_data["response"]["data"] == {}  # cleaned up to {} but still falsey
+
+
+def test_UploadFileToBatchResponseSerializer__data_and_errors():
+    invalid_response = {
+        "response": {
+            "code": "ACCEPTED",
+            "data": {"file_id": "12345"},
+            "errors": [{"key": "ERROR_KEY", "message": "Some error"}],
+        }
+    }
+    serializer = UploadFileToBatchResponseSerializer(data=invalid_response)
+    with pytest.raises(ValidationError):
+        serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
As mentioned in #45, we had a problem where uploading files would sometimes fail, basically down to a race condition with upload processing.

If a number of Jobs are created in a short time frame (or, perhaps, Smartling's API is just under load), the old approach of uploading a .po file and attaching it to a Job would fail, with "File locked" when we tried to add a just-uploaded file to that Job.

A better, more scaleable approach is to switch to the Job Batch API, which handles processing of uploads asynchronously to a particular Batch, and then associates them with the Job the Batch belongs to.

This approach works fine, and doesn't stop us from doing other Job operations (such as setting a Visual Context) while the Batch is processed.

----

This changeset has been tested locally with 10+ Jobs all being uploaded at in one sync and no problems occurred: visual context also went up fine, the files appear in Jobs in Smartling after a v short processing time, and downloads of the translated content work as before.