### PR TITLE
Simplify generation of Job names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change how we generate unique Job names (#50) - @stevejalim
 - Backfill changelog to fill in missing releases - @stevejalim
 
 ## [0.8.0] - 2024-12-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No changes yet
+
+## [0.9.0] - 2024-12-12
+
 ### Changed
 
 - Change how we generate unique Job names (#50) - @stevejalim

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 8, 0)
+VERSION = (0, 9, 0)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/models.py
+++ b/src/wagtail_localize_smartling/models.py
@@ -249,7 +249,7 @@ class Job(SyncedModel):
            is 1 in 4.2bn and we'll never generate that many jobs!)
         * `$SOURCE_ID` is the integer PK of the source object being translated.
            This is mainly because it gives us a simple, incrementing number that
-           translators can use as a quick refernece, but it can also be traced
+           translators can use as a quick reference, but it can also be traced
            back to something in the CMS if we need to. Note that this ID alone
            will not be unique across all Jobs, because it will be re-used if a
            source object were to be amended and resubmitted for translation.
@@ -268,7 +268,7 @@ class Job(SyncedModel):
 
         name = f"{hash} #{translation_source.pk}"
         if smartling_settings.JOB_NAME_PREFIX:
-            name = f"{smartling_settings.JOB_NAME_PREFIX} " + name
+            name = f"{smartling_settings.JOB_NAME_PREFIX} {name}"
         return name
 
     @staticmethod

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,11 +45,9 @@ def test_Job_get_default_name(name_prefix, smartling_settings, root_page):
 
     name = Job.get_default_name(translation_source, [page_translation])
 
-    expected_name = (
-        f"{str(translation_source.object.translation_key).split('-')[0]}:"
-        f"{translation_source.pk}:fr:2024-05-03T12:34:56"
-    )
+    expected_name = f"70018f7c #{translation_source.pk}"
+
     if name_prefix:
-        expected_name = f"{name_prefix}:" + expected_name
+        expected_name = f"{name_prefix} " + expected_name
 
     assert expected_name == name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,6 +48,6 @@ def test_Job_get_default_name(name_prefix, smartling_settings, root_page):
     expected_name = f"70018f7c #{translation_source.pk}"
 
     if name_prefix:
-        expected_name = f"{name_prefix} " + expected_name
+        expected_name = f"{name_prefix} {expected_name}"
 
     assert expected_name == name


### PR DESCRIPTION
This changeset balances the need for reliably unique Job names (even when resubmitting new translation requests for a previously translated source object) with the need for reasonably readable ones.

Resolves #50 - see there for more context if needed