### PR TITLE
Hotfix dashboard blowup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No changes
 
+## [0.10.3] - 2025-05-07
+
+Bugfix: avoid 500ing if a LandedTranslationTask references a now-deleted content object.
+
 ## [0.10.2] - 2025-01-10
 
 (Note: The deprecated 0.10.0 and 0.10.1 were code-identical to 0.10.2 but we had some packaging niggles)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/node_modules",
+    "**/.venv"
+  ],
+  "reportPrivateImportUsage": "none",
+}

--- a/src/wagtail_localize_smartling/templates/wagtail_localize_smartling/admin/components/_landed_translation_task_panel.html
+++ b/src/wagtail_localize_smartling/templates/wagtail_localize_smartling/admin/components/_landed_translation_task_panel.html
@@ -30,9 +30,13 @@
         <ul class="listing">
             {% for task in tasks %}
             <li>
+                {% if task.content_object %}
                 <a href="{{task.edit_url_for_translated_item}}">
                     {{task.content_object}} in {{task.relevant_locale.language_name}}
                 </a>
+                {% else %}
+                (Cannot show approval task #{{task.pk}} - the translated entity no longer exists)
+                {% endif %}
             </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
If, somehow, the system ends up with a LandedTranslationTask that doesn't reference a content object any more (because it uses a generic FK, there's no cascade on delete), then the task will cause the Wagtail admin root page to 500.

This changeset avoids that happening, but more work is likely needed to stamp out the root causes