### PR TITLE
Hotfix line separator blowup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No changes
 
+## [0.12.1] - 2026-04-06
+
+- Fix blow-up when invisible line breaks are in PO contnet - @stevejalim
+
 ## [0.12.0] - 2026-03-12
 
 - Support explicitly excluding locales from Smartling sync - @dchukhin

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 12, 0)
+VERSION = (0, 12, 1)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/sync.py
+++ b/src/wagtail_localize_smartling/sync.py
@@ -16,6 +16,19 @@ from .constants import PENDING_STATUSES, TRANSLATED_STATUSES, UNTRANSLATED_STATU
 from .signals import individual_translation_imported, translation_import_successful
 
 
+def _sanitize_po_content(content: str) -> str:
+    """
+    Remove Unicode line/paragraph separators (U+2028, U+2029) from PO content.
+
+    Python's str.splitlines() treats these as line boundaries, but polib uses
+    splitlines() internally to tokenize string input. If these characters appear
+    inside a quoted msgstr value, polib's parser sees a broken line and raises
+    a syntax error. Replacing them with a regular space preserves word boundaries
+    without affecting the PO file structure.
+    """
+    return content.replace("\u2028", " ").replace("\u2029", " ")
+
+
 def _compute_translation_hash(content: str) -> str:
     """
     Compute a hash of translated PO file content.
@@ -24,7 +37,7 @@ def _compute_translation_hash(content: str) -> str:
     this includes msgstr to detect changes in translations. It ignores header metadata
     (like timestamps) to ensure the hash is stable across downloads.
     """
-    po = polib.pofile(content)
+    po = polib.pofile(_sanitize_po_content(content))
     strings = []
     for entry in po:
         strings.append(f"{entry.msgctxt}:{entry.msgid}:{entry.msgstr}")
@@ -269,7 +282,7 @@ def _import_translation_for_locale(job: "Job", translation: Translation, smartli
     content = client.download_translation_for_locale(job=job, locale_id=smartling_locale_id)
     content_str = content.decode("utf-8")
     content_hash = _compute_translation_hash(content_str)
-    po_file = polib.pofile(content_str)
+    po_file = polib.pofile(_sanitize_po_content(content_str))
     translation.import_po(po_file)
     individual_translation_imported.send(
         sender=job.__class__,
@@ -328,7 +341,7 @@ def _download_and_apply_translations(job: "Job") -> None:
                         wagtail_locale_id,
                     )
 
-                po_file = polib.pofile(content)
+                po_file = polib.pofile(_sanitize_po_content(content))
                 translation.import_po(po_file)
                 individual_translation_imported.send(
                     sender=job.__class__,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,7 +9,9 @@ from django.utils import timezone
 from wagtail_localize_smartling.models import Job, JobTranslation
 from wagtail_localize_smartling.sync import (
     _check_and_import_completed_locales,
+    _compute_translation_hash,
     _import_translation_for_locale,
+    _sanitize_po_content,
 )
 
 
@@ -158,3 +160,68 @@ class TestImportTranslationForLocale:
 
         # The translation should have been imported (import_po was called)
         # We can verify by checking that no exception was raised
+
+
+class TestSanitizePoContent:
+    """Tests for _sanitize_po_content."""
+
+    def test_strips_unicode_line_separator(self):
+        content = 'msgstr "Take control \u2028of AI"'
+        assert _sanitize_po_content(content) == 'msgstr "Take control  of AI"'
+
+    def test_strips_unicode_paragraph_separator(self):
+        content = 'msgstr "Hello\u2029World"'
+        assert _sanitize_po_content(content) == 'msgstr "Hello World"'
+
+    def test_clean_content_unchanged(self):
+        content = 'msgstr "Hello World"'
+        assert _sanitize_po_content(content) == content
+
+
+class TestComputeTranslationHashWithUnicodeSeparators:
+    """Test that _compute_translation_hash handles U+2028/U+2029 in PO content."""
+
+    def test_hash_succeeds_with_unicode_line_separator_in_msgstr(self):
+        po_content = """\
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "title"
+msgid ""
+"Take control \u2028"
+"of AI"
+msgstr "Kontrolle \u2028über KI"
+"""
+        # Should not raise
+        result = _compute_translation_hash(po_content)
+        assert isinstance(result, str)
+        assert len(result) == 64  # SHA-256 hex digest
+
+
+class TestImportTranslationForLocaleWithUnicodeSeparators:
+    """Test that _import_translation_for_locale handles U+2028 in PO content."""
+
+    pytestmark = pytest.mark.django_db
+
+    def test_imports_with_unicode_line_separator_in_msgstr(
+        self,
+        smartling_job,
+        smartling_download_translation_for_locale,
+        disable_signals,
+    ):
+        po_content = """\
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "title"
+msgid ""
+"Take control \u2028"
+"of AI"
+msgstr "Kontrolle \u2028über KI"
+"""
+        smartling_download_translation_for_locale("fr", po_content=po_content)
+        translation = smartling_job.translations.first()
+        # Should not raise
+        _import_translation_for_locale(smartling_job, translation, "fr")


### PR DESCRIPTION
This changeset fixes a blow-up we were seeing in production.

polib uses str.splitlines() internally to tokenise string input. Python's splitlines() treats U+2028 (Line Separator) and U+2029 (Paragraph Separator) as line boundaries, so when these characters appear inside a translated msgstr value the parser sees a broken quoted line and raises "Syntax error in po file".

The characters originate from line breaks inserted in Wagtail source content (e.g. a soft return in a heading) and are preserved verbatim by Smartling in translations.

The fix is to swap them to a regular space before passing content to polib.
