### PR TITLE
fix: skip snippet post_save handler during fixture loading (raw=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No changes
 
+## [0.12.2] - 2026-04-20
+
+- Fix blow-up when `post_save` fires with `raw=True` (e.g. during `loaddata`) — skip snippet-published handler early and log at DEBUG - @stevejalim
+- Fix `_model_is_registered_as_snippet` being called with an instance instead of a class - @stevejalim
+
 ## [0.12.1] - 2026-04-06
 
 - Fix blow-up when invisible line breaks are in PO contnet - @stevejalim

--- a/src/wagtail_localize_smartling/__init__.py
+++ b/src/wagtail_localize_smartling/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = "wagtail_localize_smartling.apps.WagtailLocalizeSmartlingAppConfig"
 
 
-VERSION = (0, 12, 1)
+VERSION = (0, 12, 2)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_localize_smartling/signal_handlers.py
+++ b/src/wagtail_localize_smartling/signal_handlers.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _model_is_registered_as_snippet(model: "Model") -> bool:
+def _model_is_registered_as_snippet(model: Type["Model"]) -> bool:  # noqa: UP006
     """
     Check if a given model has been registered as a Wagtail snippet.
     """
@@ -77,9 +77,7 @@ def close_translation_landed_task_on_page_published(
     # is all we need
 
     if not isinstance(instance, Page):
-        logger.debug(
-            f"{instance} is not a Page, so not trying to find a landed-translation task"
-        )
+        logger.debug(f"{instance} is not a Page, so not trying to find a landed-translation task")
         return
     return _close_translation_landed_task(instance)
 
@@ -94,10 +92,16 @@ def close_translation_landed_task_on_snippet_published(
 ):
     # Both page_published and post_save send the core args, which
     # is all we need
-    if not _model_is_registered_as_snippet(instance):
-        logger.debug(
-            f"{instance} is not a Snippet, so not trying to find a landed-translation task"
-        )
+
+    # Skip during fixture loading (raw=True) — related objects may not be
+    # available yet, and landed-translation tasks should not be looked up or
+    # completed from fixture-loaded saves.
+    if kwargs.get("raw"):
+        logger.debug(f"{sender} was saved with raw=True, so not trying to find a landed-translation task")
+        return
+
+    if not _model_is_registered_as_snippet(sender):
+        logger.debug(f"{instance} is not a Snippet, so not trying to find a landed-translation task")
         return
     return _close_translation_landed_task(instance)
 
@@ -119,14 +123,10 @@ def send_email_notification_upon_overall_translation_import(
     notification option for all users in the Translation Approver group
     """
     if not smartling_settings.SEND_EMAIL_ON_TRANSLATION_IMPORT:
-        logger.info(
-            "Email notifications following translation import are disabled by settings"
-        )
+        logger.info("Email notifications following translation import are disabled by settings")
         return
 
-    ta_group = Group.objects.filter(
-        name=smartling_settings.TRANSLATION_APPROVER_GROUP_NAME
-    )
+    ta_group = Group.objects.filter(name=smartling_settings.TRANSLATION_APPROVER_GROUP_NAME)
     if not ta_group.exists():
         logger.warning(
             f"Could not find the {smartling_settings.TRANSLATION_APPROVER_GROUP_NAME} "
@@ -165,9 +165,7 @@ def send_email_notification_upon_overall_translation_import(
         context={
             "job_name": job_name,
             "translation_source_name": translation_source_name,
-            "translation_target_locales": [
-                x.target_locale for x in translations_imported
-            ],
+            "translation_target_locales": [x.target_locale for x in translations_imported],
         },
     )
 
@@ -177,11 +175,7 @@ def send_email_notification_upon_overall_translation_import(
         from_email=settings.DEFAULT_FROM_EMAIL,
         recipient_list=approver_email_addresses,
     )
-    logger.info(
-        f"Translation-imported notification sent to {len(approver_email_addresses)} users"
-    )
+    logger.info(f"Translation-imported notification sent to {len(approver_email_addresses)} users")
 
 
-translation_import_successful.connect(
-    send_email_notification_upon_overall_translation_import, weak=False
-)
+translation_import_successful.connect(send_email_notification_upon_overall_translation_import, weak=False)

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -34,18 +34,12 @@ pytestmark = [pytest.mark.django_db]
 
 def test_individual_translation_imported_is_connected_to_the_expected_handlers():
     assert len(individual_translation_imported.receivers) == 1
-    assert (
-        individual_translation_imported.receivers[0][1]
-        == create_landed_translation_task
-    )
+    assert individual_translation_imported.receivers[0][1] == create_landed_translation_task
 
 
 def test_translation_import_successful_is_connected_to_the_expected_handlers():
     assert len(translation_import_successful.receivers) == 1
-    assert (
-        translation_import_successful.receivers[0][1]
-        == send_email_notification_upon_overall_translation_import
-    )
+    assert translation_import_successful.receivers[0][1] == send_email_notification_upon_overall_translation_import
 
 
 @override_settings(
@@ -53,9 +47,7 @@ def test_translation_import_successful_is_connected_to_the_expected_handlers():
     WAGTAILADMIN_BASE_URL="https://cms.example.com",
 )
 def test_notify_of_imported_translations__happy_path(mocker):
-    mock_logger_info = mocker.patch(
-        "wagtail_localize_smartling.signal_handlers.logger.info"
-    )
+    mock_logger_info = mocker.patch("wagtail_localize_smartling.signal_handlers.logger.info")
 
     admin_1 = WagtailUserFactory(
         username="admin_1",
@@ -85,14 +77,10 @@ def test_notify_of_imported_translations__happy_path(mocker):
 
     mock_translation_fr = mocker.MagicMock(spec=Translation, name="mock-translation-fr")
     mock_translation_fr.target_locale.language_code = "fr"
-    mock_translation_fr_CA = mocker.MagicMock(
-        spec=Translation, name="mock-translation-fr-CA"
-    )
+    mock_translation_fr_CA = mocker.MagicMock(spec=Translation, name="mock-translation-fr-CA")
     mock_translation_fr_CA.target_locale.language_code = "fr-CA"
 
-    mock_send_mail = mocker.patch(
-        "wagtail_localize_smartling.signal_handlers.send_mail"
-    )
+    mock_send_mail = mocker.patch("wagtail_localize_smartling.signal_handlers.send_mail")
 
     translation_import_successful.send(
         sender=Job,
@@ -100,10 +88,7 @@ def test_notify_of_imported_translations__happy_path(mocker):
         translations_imported=[mock_translation_fr, mock_translation_fr_CA],
     )
     assert mock_send_mail.call_count == 1
-    assert (
-        mock_send_mail.call_args[1]["subject"]
-        == "New translations imported from Smartling"
-    )
+    assert mock_send_mail.call_args[1]["subject"] == "New translations imported from Smartling"
     assert mock_send_mail.call_args[1]["from_email"] == "from@example.com"
     assert mock_send_mail.call_args[1]["recipient_list"] == [
         "admin_1@example.com",
@@ -115,10 +100,7 @@ def test_notify_of_imported_translations__happy_path(mocker):
         "They are for Job 'Test Job'",
     ]:
         assert expected_string in mock_send_mail.call_args[1]["message"]
-    assert (
-        mock_logger_info.call_args_list[0][0][0]
-        == "Translation-imported notification sent to 2 users"
-    )
+    assert mock_logger_info.call_args_list[0][0][0] == "Translation-imported notification sent to 2 users"
 
 
 @pytest.mark.parametrize(
@@ -150,9 +132,7 @@ def test_notification_body_rendering(translation_target_locales):
 
 
 def test_notify_of_imported_translations__no_group_members(mocker):
-    mock_logger_warning = mocker.patch(
-        "wagtail_localize_smartling.signal_handlers.logger.warning"
-    )
+    mock_logger_warning = mocker.patch("wagtail_localize_smartling.signal_handlers.logger.warning")
 
     mock_job = mocker.MagicMock(spec=Job)
     mock_job.name = "Test Job"
@@ -162,14 +142,10 @@ def test_notify_of_imported_translations__no_group_members(mocker):
 
     mock_translation_fr = mocker.MagicMock(spec=Translation, name="mock-translation-fr")
     mock_translation_fr.target_locale.language_code = "fr"
-    mock_translation_fr_CA = mocker.MagicMock(
-        spec=Translation, name="mock-translation-fr-CA"
-    )
+    mock_translation_fr_CA = mocker.MagicMock(spec=Translation, name="mock-translation-fr-CA")
     mock_translation_fr_CA.target_locale.language_code = "fr-CA"
 
-    mock_send_mail = mocker.patch(
-        "wagtail_localize_smartling.signal_handlers.send_mail"
-    )
+    mock_send_mail = mocker.patch("wagtail_localize_smartling.signal_handlers.send_mail")
 
     translation_import_successful.send(
         sender=Job,
@@ -215,9 +191,7 @@ def test_create_landed_translation_task__disabled_by_settings(
 ):
     smartling_settings.ADD_APPROVAL_TASK_TO_DASHBOARD = False
 
-    mock_logger_debug = mocker.patch(
-        "wagtail_localize_smartling.signal_handlers.logger.debug"
-    )
+    mock_logger_debug = mocker.patch("wagtail_localize_smartling.signal_handlers.logger.debug")
     mock_create_from_source_and_translation = mocker.patch(
         "wagtail_localize_smartling.models.LandedTranslationTask.objects.create_from_source_and_translation"
     )
@@ -225,13 +199,9 @@ def test_create_landed_translation_task__disabled_by_settings(
     mock_job = mocker.MagicMock(spec=Job)
     mock_translation = mocker.MagicMock(spec=Translation)
 
-    create_landed_translation_task(
-        sender=Job, instance=mock_job, translation=mock_translation
-    )
+    create_landed_translation_task(sender=Job, instance=mock_job, translation=mock_translation)
 
-    mock_logger_debug.assert_called_once_with(
-        "Creation of a landed-translation task is disabled by settings"
-    )
+    mock_logger_debug.assert_called_once_with("Creation of a landed-translation task is disabled by settings")
     assert not mock_create_from_source_and_translation.called
 
 
@@ -319,11 +289,32 @@ def test_close_translation_landed_task_on_snippet_published(is_a_snippet, mocker
         instance=mock_instance,
     )
 
-    mock_model_is_registered_as_snippet.assert_called_once_with(mock_instance)
+    mock_model_is_registered_as_snippet.assert_called_once_with(mock_instance.__class__)
     if is_a_snippet:
         mock_close_translation_landed_task.assert_called_once_with(mock_instance)
     else:
         assert not mock_close_translation_landed_task.called
+
+
+def test_close_translation_landed_task_on_snippet_published__skips_when_raw(mocker):
+    mock_instance = mocker.Mock()
+    mock_close_translation_landed_task = mocker.patch(
+        "wagtail_localize_smartling.signal_handlers._close_translation_landed_task"
+    )
+    mock_model_is_registered_as_snippet = mocker.patch(
+        "wagtail_localize_smartling.signal_handlers._model_is_registered_as_snippet"
+    )
+    mock_logger_debug = mocker.patch("wagtail_localize_smartling.signal_handlers.logger.debug")
+
+    close_translation_landed_task_on_snippet_published(
+        sender=mock_instance.__class__,
+        instance=mock_instance,
+        raw=True,
+    )
+
+    assert not mock_model_is_registered_as_snippet.called
+    assert not mock_close_translation_landed_task.called
+    mock_logger_debug.assert_called_once()
 
 
 @pytest.mark.parametrize("is_a_snippet", [True, False])


### PR DESCRIPTION
* Also fix _model_is_registered_as_snippet being called with an instance instead of a class, which caused the check to always return False.

* Prep for release